### PR TITLE
2 Bugfixes

### DIFF
--- a/Befehle.tex
+++ b/Befehle.tex
@@ -28,7 +28,7 @@
 \begin{center}
 \begin{tabularx}{\textwidth}{|p{2cm}|X|}
 \hline
-\bf Wochen & \bf Tätigkeit und Stoff der Unterweisung\\
+\textbf Wochen & \textbf Tätigkeit und Stoff der Unterweisung\\
 \hline
 #1
 \end{tabularx}

--- a/Packages.tex
+++ b/Packages.tex
@@ -1,4 +1,4 @@
-\usepackage[utf8x]{inputenc}
+\usepackage[utf8]{inputenc}
 \usepackage[T1]{fontenc}
 \usepackage{lmodern}
 \usepackage{textcomp}


### PR DESCRIPTION
Hey,
habe festgestellt das beim Kompilieren 2 Fehler geworfen werden...

\bf wirft bei TexLive fehler, da der Befehl zu "alt" ist

utf8x ist ebenfalls unbekannt habe es durch utf8 ersetzt.

Jetzt werden keine Fehler mehr geworfen und behebt issue #1 

Cheers
ChaosRambo